### PR TITLE
Fake Builder that uploads all received bundles to Dune community table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist/

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,23 @@
+import express from "express";
+import routes from "./routes";
+
+class App {
+  public server;
+
+  constructor() {
+    this.server = express();
+
+    this.middlewares();
+    this.routes();
+  }
+
+  middlewares() {
+    this.server.use(express.json());
+  }
+
+  routes() {
+    this.server.use(routes);
+  }
+}
+
+export default new App().server;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,16 +1,23 @@
 import express from "express";
 import routes from "./routes";
 
-function configure_middlewares(server) {
-  server.use(express.json());
+class App {
+  public server;
+
+  constructor() {
+    this.server = express();
+
+    this.middlewares();
+    this.routes();
+  }
+
+  middlewares() {
+    this.server.use(express.json());
+  }
+
+  routes() {
+    this.server.use(routes);
+  }
 }
 
-function configure_routes(server) {
-  server.use(routes);
-}
-
-const server = express();
-configure_middlewares(server);
-configure_routes(server);
-
-export default server;
+export default new App().server;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,23 +1,16 @@
 import express from "express";
 import routes from "./routes";
 
-class App {
-  public server;
-
-  constructor() {
-    this.server = express();
-
-    this.middlewares();
-    this.routes();
-  }
-
-  middlewares() {
-    this.server.use(express.json());
-  }
-
-  routes() {
-    this.server.use(routes);
-  }
+function configure_middlewares(server) {
+  server.use(express.json());
 }
 
-export default new App().server;
+function configure_routes(server) {
+  server.use(routes);
+}
+
+const server = express();
+configure_middlewares(server);
+configure_routes(server);
+
+export default server;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,16 @@
+import * as t from "io-ts";
+import { getOrElse } from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+
+const config = t.type({
+  BUCKET_NAME: t.string,
+  EXTERNAL_ID: t.string,
+  ROLES_TO_ASSUME: t.string,
+});
+export type Config = t.TypeOf<typeof config>;
+export default pipe(
+  config.decode(process.env),
+  getOrElse(() => {
+    throw "Configuration error";
+  })
+);

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,5 @@
+import { Logger } from "tslog";
+export default new Logger({
+  prettyLogTemplate:
+    "{{yyyy}}-{{mm}}-{{dd}}T{{hh}}:{{MM}}:{{ss}}:{{ms}}Z {{logLevelName}} [{{filePathWithLine}}{{name}}]\t",
+});

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,31 @@
+export interface JsonRpcRequest {
+  jsonrpc: string;
+  id: string;
+  method: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: Array<any>;
+}
+
+export interface RpcBundle {
+  txs: Array<string>;
+  blockNumber: string;
+}
+
+export interface DuneBundleTransaction {
+  nonce: number;
+  maxFeePerGas: string | undefined;
+  maxPriorityFeePerGas: string | undefined;
+  gasPrice: string | undefined;
+  gasLimit: string;
+  to: string;
+  from: string;
+  value: string;
+  data: string;
+  hash: string;
+}
+
+export interface DuneBundle {
+  bundleId: string;
+  blockNumber: number;
+  transactions: Array<DuneBundleTransaction>;
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -26,6 +26,7 @@ export interface DuneBundleTransaction {
 
 export interface DuneBundle {
   bundleId: string;
+  timestamp: number;
   blockNumber: number;
   transactions: Array<DuneBundleTransaction>;
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,9 +13,9 @@ export interface RpcBundle {
 
 export interface DuneBundleTransaction {
   nonce: number;
-  maxFeePerGas: string | undefined;
-  maxPriorityFeePerGas: string | undefined;
-  gasPrice: string | undefined;
+  maxFeePerGas?: string;
+  maxPriorityFeePerGas?: string;
+  gasPrice?: string;
   gasLimit: string;
   to: string;
   from: string;

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,8 +2,7 @@ export interface JsonRpcRequest {
   jsonrpc: string;
   id: string;
   method: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: Array<any>;
+  params: Array<unknown>;
 }
 
 export interface RpcBundle {

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@ export interface JsonRpcRequest {
   jsonrpc: string;
   id: string;
   method: string;
-  params: Array<unknown>;
+  params: Array<RpcBundle>;
 }
 
 export interface RpcBundle {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,39 @@
+import { Router } from "express";
+import { RpcBundle, JsonRpcRequest } from "./models";
+import { S3Uploader } from "./upload";
+import config from "./config";
+import log from "./log";
+
+const routes = Router();
+const upload = new S3Uploader(config);
+
+routes.get("/", (req, res) => {
+  return res.json({ message: "Hello World" });
+});
+
+routes.post("/", async (req, res) => {
+  try {
+    const request: JsonRpcRequest = req.body;
+    log.trace(`Handling incoming request: ${JSON.stringify(request)}`);
+    if (request.method != "eth_sendBundle") {
+      throw "unsupported method";
+    }
+    if (request.params.length != 1) {
+      throw "expecting a single bundle";
+    }
+    const bundle: RpcBundle = request.params[0];
+    log.debug(`Received Bundle: ${JSON.stringify(bundle)}`);
+
+    await upload.upload(bundle, request.id);
+
+    res.json({
+      jsonrpc: request.jsonrpc,
+      id: request.id,
+      result: null,
+    });
+  } catch (e) {
+    res.status(500).send(e);
+  }
+});
+
+export default routes;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,7 +5,7 @@ import config from "./config";
 import log from "./log";
 
 const routes = Router();
-const upload = new S3Uploader(config);
+const aws = new S3Uploader(config);
 
 routes.get("/", (req, res) => {
   return res.json({ message: "Hello World" });
@@ -24,7 +24,8 @@ routes.post("/", async (req, res) => {
     const bundle: RpcBundle = request.params[0];
     log.debug(`Received Bundle: ${JSON.stringify(bundle)}`);
 
-    await upload.upload(bundle, request.id);
+    const bundleId = `${Number(bundle.blockNumber)}_${request.id}`;
+    await aws.upload(bundle, bundleId);
 
     res.json({
       jsonrpc: request.jsonrpc,
@@ -32,7 +33,8 @@ routes.post("/", async (req, res) => {
       result: null,
     });
   } catch (e) {
-    res.status(500).send(e);
+    log.error(e);
+    res.status(500).send();
   }
 });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,7 +8,7 @@ const routes = Router();
 const aws = new S3Uploader(config);
 
 routes.get("/", (req, res) => {
-  return res.json({ message: "Hello World" });
+  return res.json({ message: "Hello MEV Blocker" });
 });
 
 routes.post("/", async (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,2 @@
+import app from "./app";
+app.listen(8080);

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -13,7 +13,7 @@ export class S3Uploader {
   constructor(config: Config) {
     this.bucketName = config.BUCKET_NAME;
     this.externalId = config.EXTERNAL_ID;
-    this.rolesToAssume = config.ROLES_TO_ASSUME.split(',')
+    this.rolesToAssume = config.ROLES_TO_ASSUME.split(",");
   }
 
   public async createS3() {
@@ -22,17 +22,21 @@ export class S3Uploader {
     let credentials = null;
     for (const role of this.rolesToAssume) {
       log.debug(`Assuming role ${role}`);
-      const sts: STS = new STS({credentials})
-      const auth = (await sts.assumeRole({
-        RoleArn: role,
-        RoleSessionName: `mevblocker-dune-sync-${timestamp}`,
-        ExternalId: this.externalId
-      }).promise()).Credentials;
+      const sts: STS = new STS({ credentials });
+      const auth = (
+        await sts
+          .assumeRole({
+            RoleArn: role,
+            RoleSessionName: `mevblocker-dune-sync-${timestamp}`,
+            ExternalId: this.externalId,
+          })
+          .promise()
+      ).Credentials;
       credentials = {
-          accessKeyId: auth.AccessKeyId,
-          secretAccessKey: auth.SecretAccessKey,
-          sessionToken: auth.SessionToken
-      }
+        accessKeyId: auth.AccessKeyId,
+        secretAccessKey: auth.SecretAccessKey,
+        sessionToken: auth.SessionToken,
+      };
     }
 
     this.s3 = new S3(credentials);
@@ -45,13 +49,13 @@ export class S3Uploader {
         await this.createS3();
       } else {
         // if we are using a cached s3 instance we may want to retry in case of failure
-        retry = true
+        retry = true;
       }
       const params = {
         Bucket: this.bucketName,
         Key: `mevblocker_${Number(bundle.blockNumber)}_${bundleId}`,
         Body: JSON.stringify(duneBundle),
-        ACL: 'bucket-owner-full-control'
+        ACL: "bucket-owner-full-control",
       };
       log.debug(`Writing log: ${JSON.stringify(duneBundle)}`);
       const res = await this.s3.upload(params).promise();
@@ -61,7 +65,7 @@ export class S3Uploader {
       // Make sure we re-initialize the connection next time
       this.s3 = undefined;
       if (retry) {
-        this.upload(bundle, bundleId)
+        this.upload(bundle, bundleId);
       }
     }
   }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,0 +1,92 @@
+import { DuneBundle, DuneBundleTransaction, RpcBundle } from "./models";
+import { S3, STS } from "aws-sdk";
+import log from "./log";
+import { Config } from "./config";
+import { ethers } from "ethers";
+
+export class S3Uploader {
+  private bucketName: string;
+  private externalId: string;
+  private rolesToAssume: Array<string>;
+  private s3: S3;
+
+  constructor(config: Config) {
+    this.bucketName = config.BUCKET_NAME;
+    this.externalId = config.EXTERNAL_ID;
+    this.rolesToAssume = config.ROLES_TO_ASSUME.split(',')
+  }
+
+  public async createS3() {
+    log.debug(`Creating S3 instance`);
+    const timestamp = new Date().getTime();
+    let credentials = null;
+    for (const role of this.rolesToAssume) {
+      log.debug(`Assuming role ${role}`);
+      const sts: STS = new STS({credentials})
+      const auth = (await sts.assumeRole({
+        RoleArn: role,
+        RoleSessionName: `mevblocker-dune-sync-${timestamp}`,
+        ExternalId: this.externalId
+      }).promise()).Credentials;
+      credentials = {
+          accessKeyId: auth.AccessKeyId,
+          secretAccessKey: auth.SecretAccessKey,
+          sessionToken: auth.SessionToken
+      }
+    }
+
+    this.s3 = new S3(credentials);
+  }
+  public async upload(bundle: RpcBundle, bundleId: string) {
+    const duneBundle = convertBundle(bundle, bundleId);
+    let retry = false;
+    try {
+      if (!this.s3) {
+        await this.createS3();
+      } else {
+        // if we are using a cached s3 instance we may want to retry in case of failure
+        retry = true
+      }
+      const params = {
+        Bucket: this.bucketName,
+        Key: `mevblocker_${Number(bundle.blockNumber)}_${bundleId}`,
+        Body: JSON.stringify(duneBundle),
+        ACL: 'bucket-owner-full-control'
+      };
+      log.debug(`Writing log: ${JSON.stringify(duneBundle)}`);
+      const res = await this.s3.upload(params).promise();
+      log.debug(`File Uploaded successfully ${res.Location}`);
+    } catch (error) {
+      log.error(`Unable to Upload the file: ${error}, retrying: ${retry}`);
+      // Make sure we re-initialize the connection next time
+      this.s3 = undefined;
+      if (retry) {
+        this.upload(bundle, bundleId)
+      }
+    }
+  }
+}
+
+export function convertBundle(bundle: RpcBundle, bundleId: string): DuneBundle {
+  return {
+    blockNumber: Number(bundle.blockNumber),
+    bundleId,
+    transactions: bundle.txs.map((tx) => decodeTx(tx)),
+  };
+}
+
+function decodeTx(tx: string): DuneBundleTransaction {
+  const parsed = ethers.utils.parseTransaction(tx);
+  return {
+    nonce: parsed.nonce,
+    maxFeePerGas: parsed.maxFeePerGas?.toString(),
+    maxPriorityFeePerGas: parsed.maxPriorityFeePerGas?.toString(),
+    gasPrice: parsed.gasPrice?.toString(),
+    gasLimit: parsed.gasLimit.toString(),
+    to: parsed.to,
+    from: parsed.from,
+    value: parsed.value.toString(),
+    data: parsed.data,
+    hash: parsed.hash,
+  };
+}

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -1,0 +1,32 @@
+import { RpcBundle } from "../src/models";
+import { convertBundle } from "../src/upload";
+
+describe("testing bundle conversion", () => {
+  test("succesfully decodes raw transaction", () => {
+    const bundle: RpcBundle = {
+      txs: [
+        "0x02f8b10181db8459682f00850c9f5014d282be9894a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4880b844a9059cbb0000000000000000000000005408b27504dfcf7b0c3edf116e847aa19ce7f03c0000000000000000000000000000000000000000000000000000001e449a9400c080a049c0f50df4219481e031ac35816946daef9d08004f3324f7f46f6938488025aba02a4bda81f792bc5b7033804e39b7e55e619e56de1afcddd2ae4943ae5e7737c4",
+      ],
+      blockNumber: "0x1",
+    };
+    const result = convertBundle(bundle, "42");
+    expect(result).toStrictEqual({
+      bundleId: "42",
+      blockNumber: 1,
+      transactions: [
+        {
+          nonce: 219,
+          maxPriorityFeePerGas: "1500000000",
+          maxFeePerGas: "54212433106",
+          gasPrice: undefined,
+          gasLimit: "48792",
+          to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          from: "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+          value: "0",
+          data: "0xa9059cbb0000000000000000000000005408b27504dfcf7b0c3edf116e847aa19ce7f03c0000000000000000000000000000000000000000000000000000001e449a9400",
+          hash: "0x07151ed9706e4dffb31eaaac2ed1be5c6f05a9eef63c8f7c6ecad9ca8731aa22",
+        },
+      ],
+    });
+  });
+});

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -9,9 +9,10 @@ describe("testing bundle conversion", () => {
       ],
       blockNumber: "0x1",
     };
-    const result = convertBundle(bundle, "42");
+    const result = convertBundle(bundle, "42", 69);
     expect(result).toStrictEqual({
       bundleId: "42",
+      timestamp: 69,
       blockNumber: 1,
       transactions: [
         {


### PR DESCRIPTION
This PR implements a simple web service that accepts `eth_sendBundle` RPC calls and writes the received bundle into an S3 bucket that was provided to us by Dune (one request = one file), always returning success to the calling endpoint).

This will make all received bundles available transparently in Dune for further analytics of MEV Blocker flow.

## References
- https://docs.builder0x69.io/ for what interface we are implementing in this service
- https://hackmd.io/unWaHW-RSjWWX6Q_3Zzfeg on how to write into Dune

## Test Plan

Credentials in [1 Password](https://start.1password.com/open/i?a=6DWD777JFFEZZLYS6J4DUURYLE&v=weisopuq6vd4jkgfi443z2fe64&i=irnnqyo73swamnizk5kycnkva4&h=cowserviceslda.1password.com)
```
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
export EXTERNAL_ID="..."
export BUCKET=arrakis-landing-zone-relays-dev-118330671040
export ROLES_TO_ASSUME=arn:aws:iam::133876976458:role/dune-mevblocker-sync,arn:aws:iam::118330671040:role/dev-relays-crossaccount

yarn start:dev
curl -s --data '{"jsonrpc": "2.0","id": "42069","method": "eth_sendBundle","params": [{"txs": ["0x02f8b10181db8459682f00850c9f5014d282be9894a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4880b844a9059cbb0000000000000000000000005408b27504dfcf7b0c3edf116e847aa19ce7f03c0000000000000000000000000000000000000000000000000000001e449a9400c080a049c0f50df4219481e031ac35816946daef9d08004f3324f7f46f6938488025aba02a4bda81f792bc5b7033804e39b7e55e619e56de1afcddd2ae4943ae5e7737c4"],"blockNumber": "0xf79d4e","refundPercent": 99,"refundRecipient": "0xab5801a7d398351b8be11c439e05c5b3259aec9b"}]}' -H "Content-Type: application/json" -X POST localhost:8080
```