### PR TITLE
Adding prometheus metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "aws-sdk": "^2.1360.0",
     "ethers": "^5.7.0",
     "express": "^4.18.2",
+    "express-prom-bundle": "^6.6.0",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
+    "prom-client": "^14.2.0",
     "tslog": "^4.8.2"
   },
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import routes from "./routes";
+import promBundle from "express-prom-bundle";
 
 class App {
   public server;
@@ -13,6 +14,13 @@ class App {
 
   middlewares() {
     this.server.use(express.json());
+    this.server.use(
+      promBundle({
+        includeMethod: true,
+        includePath: true,
+        includeStatusCode: true,
+      })
+    );
   }
 
   routes() {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -16,10 +16,14 @@ routes.post("/", async (req, res) => {
     const request: JsonRpcRequest = req.body;
     log.trace(`Handling incoming request: ${JSON.stringify(request)}`);
     if (request.method != "eth_sendBundle") {
-      throw "unsupported method";
+      log.debug("unsupported method");
+      res.status(405).send();
+      return;
     }
     if (request.params.length != 1) {
-      throw "expecting a single bundle";
+      log.warn("expecting a single bundle");
+      res.status(400).send();
+      return;
     }
     const bundle: RpcBundle = request.params[0];
     log.debug(`Received Bundle: ${JSON.stringify(bundle)}`);

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -51,6 +51,8 @@ export class S3Uploader {
       this.s3 = undefined;
       if (retry) {
         this.upload(bundle, bundleId);
+      } else {
+        throw error;
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,6 +1472,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
 bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
@@ -2063,6 +2068,14 @@ expect@^29.0.0, expect@^29.5.0:
     jest-matcher-utils "^29.5.0"
     jest-message-util "^29.5.0"
     jest-util "^29.5.0"
+
+express-prom-bundle@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/express-prom-bundle/-/express-prom-bundle-6.6.0.tgz#9c33c1bd1478d70e3961a53aed2d17f15ef821ca"
+  integrity sha512-tZh2P2p5a8/yxQ5VbRav011Poa4R0mHqdFwn9Swe/obXDe5F0jY9wtRAfNYnqk4LXY7akyvR/nrvAHxQPWUjsQ==
+  dependencies:
+    on-finished "^2.3.0"
+    url-value-parser "^2.0.0"
 
 express@^4.18.2:
   version "4.18.2"
@@ -3260,7 +3273,7 @@ object-inspect@^1.9.0:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -3418,6 +3431,13 @@ pretty-format@^29.0.0, pretty-format@^29.5.0:
     "@jest/schemas" "^29.4.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
 
 prompts@^2.0.1:
   version "2.4.2"
@@ -3773,6 +3793,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
@@ -3925,6 +3952,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-value-parser@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/url-value-parser/-/url-value-parser-2.2.0.tgz#f38ae8cd24604ec69bc219d66929ddbbd93a2b32"
+  integrity sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A==
 
 url@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
In order to setup metrics based alerts, I changed the logic a bit to return meaningful status codes (405 for unsupported methods, 400 for bad requests and 500 in case the upload fails).

This allows us to use off-the-shelf prometheus middleware to track our success rate, response time and other basic RED metrics (which we can use to create alerts)

### Test Plan
Run server, make a few requests, see prometheus metrics being exposed on `/metrics`

cc @mateipopa as I will likely need some help exposing these metrics in our Grafana instance.