### PR TITLE
Record referrer on bundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,4 @@ jobs:
             ${{ matrix.os }}-yarn-
       - run: yarn --frozen-lockfile
       - run: yarn lint
+      - run: yarn test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,6 @@ export default async (): Promise<Config> => {
     transform: { "^.+\\.ts?$": "ts-jest" },
     testEnvironment: "node",
     testRegex: "/tests/.*\\.(test|spec)?\\.(ts|tsx)$",
-    moduleFileExtensions: ["ts", "json", "node"],
+    moduleFileExtensions: ["js", "ts", "json", "node"],
   };
 };

--- a/src/models.ts
+++ b/src/models.ts
@@ -28,4 +28,5 @@ export interface DuneBundle {
   timestamp: number;
   blockNumber: number;
   transactions: Array<DuneBundleTransaction>;
+  referrer?: string;
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -29,7 +29,10 @@ routes.post("/", async (req, res) => {
     log.debug(`Received Bundle: ${JSON.stringify(bundle)}`);
 
     const bundleId = `${Number(bundle.blockNumber)}_${request.id}`;
-    await aws.upload(bundle, bundleId);
+    // Context on spelling https://www.sistrix.com/ask-sistrix/technical-seo/http/http-referrer/
+    const referrer: string =
+      req.headers.referer || (req.headers.referrer as string);
+    await aws.upload(bundle, bundleId, referrer);
 
     res.json({
       jsonrpc: request.jsonrpc,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -31,7 +31,7 @@ routes.post("/", async (req, res) => {
     const bundleId = `${Number(bundle.blockNumber)}_${request.id}`;
     // Context on spelling https://www.sistrix.com/ask-sistrix/technical-seo/http/http-referrer/
     const referrer: string =
-      req.headers.referer || (req.headers.referrer as string);
+      (req.headers.referrer as string) || req.headers.referer;
     await aws.upload(bundle, bundleId, referrer);
 
     res.json({

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -25,9 +25,9 @@ export class S3Uploader {
     log.debug(`Creating S3 instance`);
     this.s3 = new S3(credentials);
   }
-  public async upload(bundle: RpcBundle, bundleId: string) {
+  public async upload(bundle: RpcBundle, bundleId: string, referrer?: string) {
     const timestamp = new Date().getTime();
-    const duneBundle = convertBundle(bundle, bundleId, timestamp);
+    const duneBundle = convertBundle(bundle, bundleId, timestamp, referrer);
     let retry = false;
     try {
       if (!this.s3) {
@@ -90,13 +90,15 @@ async function assumeRoles(
 export function convertBundle(
   bundle: RpcBundle,
   bundleId: string,
-  timestamp: number
+  timestamp: number,
+  referrer?: string
 ): DuneBundle {
   return {
     bundleId,
     timestamp,
     blockNumber: Number(bundle.blockNumber),
     transactions: bundle.txs.map((tx) => decodeTx(tx)),
+    referrer,
   };
 }
 

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -9,7 +9,7 @@ describe("testing bundle conversion", () => {
       ],
       blockNumber: "0x1",
     };
-    const result = convertBundle(bundle, "42", 69);
+    const result = convertBundle(bundle, "42", 69, "CoW Swap");
     expect(result).toStrictEqual({
       bundleId: "42",
       timestamp: 69,
@@ -28,6 +28,7 @@ describe("testing bundle conversion", () => {
           hash: "0x07151ed9706e4dffb31eaaac2ed1be5c6f05a9eef63c8f7c6ecad9ca8731aa22",
         },
       ],
+      referrer: "CoW Swap",
     });
   });
 });


### PR DESCRIPTION
In order to track where our transaction flow is coming from we receive an optional referrer tag in the header of the request, that we now will add into Dune.

Since we a re adding a column, this will require indexing on their end. It's my understanding that this won't lead to any data loss though, so it's probably cleaner than adding it to the transaction json (where it would be duplicated and not semantically it isn't really part of a transaction).