### PR TITLE
Log revert protection

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -8,6 +8,7 @@ export interface JsonRpcRequest {
 export interface RpcBundle {
   txs: Array<string>;
   blockNumber: string;
+  revertingTxHashes?: Array<string>;
 }
 
 export interface DuneBundleTransaction {
@@ -21,6 +22,7 @@ export interface DuneBundleTransaction {
   value: string;
   data: string;
   hash: string;
+  revertProtected: boolean;
 }
 
 export interface DuneBundle {

--- a/src/models.ts
+++ b/src/models.ts
@@ -22,7 +22,7 @@ export interface DuneBundleTransaction {
   value: string;
   data: string;
   hash: string;
-  revertProtected: boolean;
+  mayRevert: boolean;
 }
 
 export interface DuneBundle {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -109,7 +109,7 @@ function decodeTx(
   revertingTxHashes?: Array<string>
 ): DuneBundleTransaction {
   const parsed = ethers.utils.parseTransaction(tx);
-  const revertProtected =
+  const mayRevert =
     revertingTxHashes !== undefined
       ? revertingTxHashes
           .map((h) => h.toLocaleLowerCase())
@@ -126,6 +126,6 @@ function decodeTx(
     value: parsed.value.toString(),
     data: parsed.data,
     hash: parsed.hash,
-    revertProtected,
+    mayRevert,
   };
 }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -112,7 +112,7 @@ function decodeTx(
   const mayRevert =
     revertingTxHashes !== undefined
       ? revertingTxHashes
-          .map((h) => h.toLocaleLowerCase())
+          .map((h) => h.toLowerCase())
           .includes(parsed.hash.toLowerCase())
       : false;
   return {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -97,13 +97,24 @@ export function convertBundle(
     bundleId,
     timestamp,
     blockNumber: Number(bundle.blockNumber),
-    transactions: bundle.txs.map((tx) => decodeTx(tx)),
+    transactions: bundle.txs.map((tx) =>
+      decodeTx(tx, bundle.revertingTxHashes)
+    ),
     referrer,
   };
 }
 
-function decodeTx(tx: string): DuneBundleTransaction {
+function decodeTx(
+  tx: string,
+  revertingTxHashes?: Array<string>
+): DuneBundleTransaction {
   const parsed = ethers.utils.parseTransaction(tx);
+  const revertProtected =
+    revertingTxHashes !== undefined
+      ? revertingTxHashes
+          .map((h) => h.toLocaleLowerCase())
+          .includes(parsed.hash.toLowerCase())
+      : false;
   return {
     nonce: parsed.nonce,
     maxFeePerGas: parsed.maxFeePerGas?.toString(),
@@ -115,5 +126,6 @@ function decodeTx(tx: string): DuneBundleTransaction {
     value: parsed.value.toString(),
     data: parsed.data,
     hash: parsed.hash,
+    revertProtected,
   };
 }

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -26,7 +26,7 @@ describe("testing bundle conversion", () => {
           value: "0",
           data: "0xa9059cbb0000000000000000000000005408b27504dfcf7b0c3edf116e847aa19ce7f03c0000000000000000000000000000000000000000000000000000001e449a9400",
           hash: "0x07151ed9706e4dffb31eaaac2ed1be5c6f05a9eef63c8f7c6ecad9ca8731aa22",
-          revertProtected: false,
+          mayRevert: false,
         },
       ],
       referrer: "CoW Swap",

--- a/tests/upload.test.ts
+++ b/tests/upload.test.ts
@@ -26,6 +26,7 @@ describe("testing bundle conversion", () => {
           value: "0",
           data: "0xa9059cbb0000000000000000000000005408b27504dfcf7b0c3edf116e847aa19ce7f03c0000000000000000000000000000000000000000000000000000001e449a9400",
           hash: "0x07151ed9706e4dffb31eaaac2ed1be5c6f05a9eef63c8f7c6ecad9ca8731aa22",
+          revertProtected: false,
         },
       ],
       referrer: "CoW Swap",


### PR DESCRIPTION
For more accurate metrics on average inclusion time it makes sense to slice transactions based on whether they were sent to the `/noreverts` endpoint or not (the latter requires simulation on the builder side for which they might have less capacity and therefore fewer blockspace available per block).

We already get this information in the endpoint, we just have to encode it on the tx. For dune, the logic should be that if there exist a single entry for the tx (in particular the bundle containing only the user tx) for which mayRevert is true they were sent via the default endpoint (only if none of the txs is allowed to revert it was sent via the `/norevert` endpoint)