### PR TITLE
Add configurable delay before uploading to AWS

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,10 +6,17 @@ const config = t.type({
   BUCKET_NAME: t.string,
   EXTERNAL_ID: t.string,
   ROLES_TO_ASSUME: t.string,
+  UPLOAD_DELAY: t.number,
 });
+
+const parsedEnv = {
+  ...process.env,
+  UPLOAD_DELAY: parseInt(process.env.UPLOAD_DELAY, 10),
+};
+
 export type Config = t.TypeOf<typeof config>;
 export default pipe(
-  config.decode(process.env),
+  config.decode(parsedEnv),
   getOrElse(() => {
     throw "Configuration error";
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,12 +6,12 @@ const config = t.type({
   BUCKET_NAME: t.string,
   EXTERNAL_ID: t.string,
   ROLES_TO_ASSUME: t.string,
-  UPLOAD_DELAY: t.number,
+  UPLOAD_DELAY_MS: t.number,
 });
 
 const parsedEnv = {
   ...process.env,
-  UPLOAD_DELAY: parseInt(process.env.UPLOAD_DELAY, 10),
+  UPLOAD_DELAY_MS: parseInt(process.env.UPLOAD_DELAY_MS, 10),
 };
 
 export type Config = t.TypeOf<typeof config>;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -46,7 +46,7 @@ routes.post("/", async (req, res) => {
       } catch (e) {
         log.debug(e);
       }
-    }, (config as Config).UPLOAD_DELAY);
+    }, (config as Config).UPLOAD_DELAY_MS);
   } catch (e) {
     log.debug(e);
     res.status(500).send();


### PR DESCRIPTION
We used to upload incoming bundles immediately and only then respond to the incoming request. However, in order to make this server compatible with potentially other subscribers that don't have inherent delays such as Dune, we want to configure explicit delays before the data is forwarded (to avoid information leakage). This PR achieves this.

## Changes

- [x] Allow for a configurable upload delay 
- [x] Return from the request immediately after parsing the bundle but before uploading it
- [x] Upload the bundle in asyn post processing after the delay

## Test Plan
Locally send a bundle like

```
curl -s --data '{"jsonrpc": "2.0","id": "42069","method": "eth_sendBundle","params": [{"txs": ["0x02f8b10181db8
459682f00850c9f5014d282be9894a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4880b844a9059cbb0000000000000000000000005408b27504dfcf7b0c3edf116e847aa19ce7f03c000000000000
0000000000000000000000000000000000000000001e449a9400c080a049c0f50df4219481e031ac35816946daef9d08004f3324f7f46f6938488025aba02a4bda81f792bc5b7033804e39b7e55e619
e56de1afcddd2ae4943ae5e7737c4"],"blockNumber": "0xf79d4e","refundPercent": 99,"refundRecipient": "0xab5801a7d398351b8be11c439e05c5b3259aec9b"}]}' -H "Content-T
ype: application/json" -H "referer: foobar" -X POST localhost:8080
```

Observe request returning immediately, but upload only happening after the delay.