### PR TITLE
Capture timestamp when bundle is received

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,7 +43,7 @@ routes.post("/", async (req, res) => {
     setTimeout(async () => {
       try {
         log.debug(`Uploading bundle ${bundleId}`);
-        await aws.upload(bundle, bundleId, timestamp, referrer);
+        await aws.upload({ bundle, bundleId, timestamp, referrer });
       } catch (e) {
         log.debug(e);
       }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -37,12 +37,13 @@ routes.post("/", async (req, res) => {
       id: request.id,
       result: null,
     });
+    const timestamp = new Date().getTime();
 
     // Only upload after some delay
     setTimeout(async () => {
       try {
         log.debug(`Uploading bundle ${bundleId}`);
-        await aws.upload(bundle, bundleId, referrer);
+        await aws.upload(bundle, bundleId, timestamp, referrer);
       } catch (e) {
         log.debug(e);
       }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -3,7 +3,13 @@ import { S3, STS } from "aws-sdk";
 import log from "./log";
 import { Config } from "./config";
 import { ethers } from "ethers";
-import { time } from "console";
+
+interface UploadParams {
+  bundle: RpcBundle;
+  bundleId: string;
+  timestamp: number;
+  referrer?: string;
+}
 
 export class S3Uploader {
   private bucketName: string;
@@ -26,12 +32,7 @@ export class S3Uploader {
     log.debug(`Creating S3 instance`);
     this.s3 = new S3(credentials);
   }
-  public async upload(
-    bundle: RpcBundle,
-    bundleId: string,
-    timestamp: number,
-    referrer?: string
-  ) {
+  public async upload({ bundle, bundleId, timestamp, referrer }: UploadParams) {
     const duneBundle = convertBundle(bundle, bundleId, timestamp, referrer);
     let retry = false;
     try {
@@ -57,7 +58,7 @@ export class S3Uploader {
       // Make sure we re-initialize the connection next time
       this.s3 = undefined;
       if (retry) {
-        this.upload(bundle, bundleId, timestamp, referrer);
+        this.upload({ bundle, bundleId, timestamp, referrer });
       } else {
         throw error;
       }

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -3,6 +3,7 @@ import { S3, STS } from "aws-sdk";
 import log from "./log";
 import { Config } from "./config";
 import { ethers } from "ethers";
+import { time } from "console";
 
 export class S3Uploader {
   private bucketName: string;
@@ -25,8 +26,12 @@ export class S3Uploader {
     log.debug(`Creating S3 instance`);
     this.s3 = new S3(credentials);
   }
-  public async upload(bundle: RpcBundle, bundleId: string, referrer?: string) {
-    const timestamp = new Date().getTime();
+  public async upload(
+    bundle: RpcBundle,
+    bundleId: string,
+    timestamp: number,
+    referrer?: string
+  ) {
     const duneBundle = convertBundle(bundle, bundleId, timestamp, referrer);
     let retry = false;
     try {
@@ -52,7 +57,7 @@ export class S3Uploader {
       // Make sure we re-initialize the connection next time
       this.s3 = undefined;
       if (retry) {
-        this.upload(bundle, bundleId);
+        this.upload(bundle, bundleId, timestamp, referrer);
       } else {
         throw error;
       }


### PR DESCRIPTION
#10 made it so that we delay uploading of bundles for a configurable amount of time. However, this has caused our timestamps to also become delayed as we capture the current time only after the delay has passed.

This PR makes it so that we capture the current time as soon as we receive the bundle, then wait for the delay before uploading the bundle to S3.