### PR TITLE
Allow for particularly large bundles

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ class App {
   }
 
   middlewares() {
-    this.server.use(express.json());
+    this.server.use(express.json({ limit: "10mb" }));
     this.server.use(
       promBundle({
         includeMethod: true,


### PR DESCRIPTION
Default size is 100kB and we are sometimes running into `PayloadTooLarge` errors.