### PR TITLE
Configure region for S3 bucket

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ const config = t.type({
   EXTERNAL_ID: t.string,
   ROLES_TO_ASSUME: t.string,
   UPLOAD_DELAY_MS: t.number,
+  REGION: t.string,
 });
 
 const parsedEnv = {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -17,12 +17,14 @@ export class S3Uploader {
   private bucketName: string;
   private externalId: string;
   private rolesToAssume: Array<string>;
+  private region: string;
   private s3: S3;
 
   constructor(config: Config) {
     this.bucketName = config.BUCKET_NAME;
     this.externalId = config.EXTERNAL_ID;
     this.rolesToAssume = config.ROLES_TO_ASSUME.split(",");
+    this.region = config.REGION;
   }
 
   public async createS3(timestamp: number) {
@@ -32,7 +34,7 @@ export class S3Uploader {
       timestamp
     );
     log.debug(`Creating S3 instance`);
-    this.s3 = new S3(credentials);
+    this.s3 = new S3({ ...credentials, region: this.region });
   }
   public async upload({ bundle, bundleId, timestamp, referrer }: UploadParams) {
     const duneBundle = convertBundle(bundle, bundleId, timestamp, referrer);


### PR DESCRIPTION
According to [stack overflow](https://stackoverflow.com/questions/25027462/aws-s3-the-bucket-you-are-attempting-to-access-must-be-addressed-using-the-spec/71416876#71416876) v3 of the AWS SDK now expects you to explicitly configure the region of the AWS bucket.