### PR TITLE
Bump Ethers to v6.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@aws-sdk/client-sts": "^3.787.0",
     "@aws-sdk/lib-storage": "^3.787.0",
     "@aws-sdk/node-http-handler": "^3.374.0",
-    "ethers": "^6.13.5",
+    "ethers": "^6.15.0",
     "express": "^4.18.2",
     "express-prom-bundle": "^6.6.0",
     "fp-ts": "^2.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,10 +2786,10 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-ethers@^6.13.5:
-  version "6.13.5"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz"
-  integrity sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==
+ethers@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.15.0.tgz#2980f2a3baf0509749b7e21f8692fa8a8349c0e3"
+  integrity sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==
   dependencies:
     "@adraffy/ens-normalize" "1.10.1"
     "@noble/curves" "1.2.0"


### PR DESCRIPTION
We are seeing a bunch of logs like

>  WARN [/dist/upload.js:221] Failed to decode transaction, skipping. Reason: unsupported transaction type (operation="from", code=UNSUPPORTED_OPERATION, version=6.13.5)

which are likely coming from the new transaction type (EIP7702) that was introduced in Pectra. This PR bumps the ethers js version so that this new transaction type can be successfully decoded.

Support for this was added in [v6.14.0](https://github.com/ethers-io/ethers.js/releases/tag/v6.14.0)